### PR TITLE
add execution count tracking

### DIFF
--- a/pystata-kernel/kernel.py
+++ b/pystata-kernel/kernel.py
@@ -25,6 +25,7 @@ class PyStataKernel(IPythonKernel):
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
         self.stata_ready = False
+	self.shell.execution_count = 0
 
     def do_execute(self, code, silent, store_history=True, user_expressions=None,
                    allow_stdin=False):
@@ -48,6 +49,7 @@ class PyStataKernel(IPythonKernel):
         # Execute Stata code
         from pystata.stata import run
         run(code, quietly=False, inline=True)
+	self.shell.execution_count += 1
 
         return {'status': 'ok',
             'execution_count': self.execution_count,


### PR DESCRIPTION
The more general ipykernel.kernelbase.Kernel includes execution tracking, but ipykernel.ipkernel.IPythonKernel assumes the execution_count comes from the shell. This commit manually sets the execution count, so that it will update as cells are run.