### PR TITLE
use -tempvar- for browse magic selection variables

### DIFF
--- a/pystata-kernel/magics.py
+++ b/pystata-kernel/magics.py
@@ -27,32 +27,15 @@ def count():
 class SelVar():
     """
     Class for generating selection var in Stata
-    TO DO: Keep track of names being used
     """
     def __init__(self,condition):
-        condition = condition.replace('if ','').strip()
+        condition = condition.replace('if ','',1).strip()
         if condition == '':
             self.varname = None
         else:
-            self.varname = "pystataTmp_" + str(random.randrange(1000,9999))      
-            cmd = f"gen {self.varname} = cond({condition},1,0)"
-            pystata.stata.run(cmd, quietly=True)        
-        
-    def clear(self):
-        if self.varname != None:
-            pystata.stata.run(f"capture drop {self.varname}", quietly=True)            
-
-
-def genSelVar(condition):
-    condition = condition.replace(' if ','').strip()
-    # TODO: create a tmp var class to keep track of things
-    varname = "pystataTmp_" + str(random.randrange(1000,9999))
-    
-    # Gen selection var in Stata
-    cmd = f"gen {varname} = cond({condition},1,0)"
-    pystata.stata.run(cmd, quietly=True)
-
-    return varname
+            cmd = f"tempvar __selectionVar\ngenerate `__selectionVar' = cond({condition},1,0)"
+            pystata.stata.run(cmd, quietly=True)      
+            self.varname = sfi.Macro.getLocal("__selectionVar")  
 
 def InVar(code):
     """
@@ -148,12 +131,6 @@ class StataMagics():
         except Exception as e:
             msg = "Failed to browse data.\r\n{0}"
             print_kernel(msg.format(e), kernel)
-
-        if sel_var != None:
-            # Drop selection var in Stata. We put this outside of try to ensure 
-            # the temp variable gets deleted even when there is an error.
-            #pystata.stata.run(f"capture drop {sel_var}", quietly=True)            
-            sel_var.clear()
 
         return ''
 


### PR DESCRIPTION
I've tweaked the SelVar class to use Stata's [`tempvar`][1] command to name the variables. This has a couple of advantages:

- Stata cleans up after `tempvar`s itself, which eliminates the need to explicitly drop them
- Stata will ensure `tempvar`s are non-colliding with any existing variable name
- Generating a `tempvar` does not mark the dataset as dirty

Since `tempvar`s are syntactic sugar for a local macro, I use sfi to fetch the value they resolve to in order to populate `SelVar.varname` rather than using a unique variable name on the python side of things. `tempvar` itself has no problem being supplied the same string again and again.

[1]: https://www.stata.com/manuals/pmacro.pdf#pmacroRemarksandexamplesThetempvar%2Ctempname%2Candtempfilecommands

I also made a minor change to the invocation of `.replace` on the selection condition so it only replaces the first instance of "`if `", just in case there's a variable in the varlist that happens to end in those characters.