### PR TITLE
improve generation of pandas dataframes

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ The following settings are permitted inside the configuration file:
     - 'False': the kernel will not echo single commands. 
     Default is 'False'.
 - `splash`: controls display of the splash message during Stata startup. Default is 'True'.
+- `missing`: What should be displayed in the output of the `%browse` magic for a missing value. Default is '.', following Stata. To defer to pandas' format for `NA`s, specify `None`.
 
 Settings must be under the title `[pystata-kernel]`. Example:
 

--- a/pystata-kernel/config.py
+++ b/pystata-kernel/config.py
@@ -16,7 +16,8 @@ def get_config():
             'edition': None, 
             'graph_format': 'png',
             'echo': 'False',
-            'splash': 'True'
+            'splash': 'True',
+            'missing': '.'
             }
 
     for cpath in (global_config_path,user_config_path):

--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -1,0 +1,38 @@
+import pandas as pd
+import numpy as np
+import pystata
+import sfi
+
+def better_pdataframe_from_data(var=None, obs=None, selectvar=None, valuelabel=False, missingval=np.NaN):
+    pystata.config.check_initialized()
+
+    return better_dataframe_from_stata(None, var, obs, selectvar, valuelabel, missingval)
+
+
+def better_pdataframe_from_frame(stfr, var=None, obs=None, selectvar=None, valuelabel=False, missingval=np.NaN):
+    pystata.config.check_initialized()
+
+    return better_dataframe_from_stata(stfr, var, obs, selectvar, valuelabel, missingval)
+
+
+def better_dataframe_from_stata(stfr, var, obs, selectvar, valuelabel, missingval):
+    hdl = sfi.Data if stfr is None else sfi.Frame.connect(stfr)
+
+    if hdl.getObsTotal() <= 0:
+        return None
+
+    pystata.stata.run("""tempvar indexvar
+                         generate `indexvar' = _n""", quietly=True)
+    idx_var = sfi.Macro.getLocal('indexvar')
+
+    data = hdl.getAsDict(var, obs, selectvar, valuelabel, missingval)
+    if idx_var in data:
+        idx = data.pop(idx_var)
+    else:
+        idx = hdl.getAsDict(idx_var, obs, selectvar, valuelabel, missingval).pop(idx_var)
+
+    idx = pd.array(idx, dtype='Int64')
+
+    pystata.stata.run("drop `indexvar'")
+
+    return pd.DataFrame(data=data, index=idx).convert_dtypes()

--- a/pystata-kernel/magics.py
+++ b/pystata-kernel/magics.py
@@ -7,6 +7,7 @@ from bs4 import BeautifulSoup as bs
 from argparse import ArgumentParser, SUPPRESS
 from pkg_resources import resource_filename
 from .helpers import better_pdataframe_from_data
+from .config import get_config
 
 import pystata
 import sfi
@@ -94,6 +95,7 @@ class StataMagics():
         return code        
 
     def magic_browse(self,args,kernel):
+        env = get_config()
         N_max = 200
         vars = None
 
@@ -126,6 +128,10 @@ class StataMagics():
                                                     missingval=np.NaN)
             if vars == None and sel_var.varname != None:
                 df = df.drop([sel_var.varname],axis=1)
+            
+            if env['missing'] is not None:
+                df = df.astype('string').fillna(env['missing'])
+                
             html = df.to_html(notebook=True)
 
             content = {

--- a/pystata-kernel/magics.py
+++ b/pystata-kernel/magics.py
@@ -6,6 +6,7 @@ from textwrap import dedent
 from bs4 import BeautifulSoup as bs
 from argparse import ArgumentParser, SUPPRESS
 from pkg_resources import resource_filename
+from .helpers import better_pdataframe_from_data
 
 import pystata
 import sfi
@@ -54,35 +55,6 @@ def InVar(code):
     if start.strip() == 'f': start = 1
     if end.strip() == 'l': end = count()
     return (int(start)-1, int(end))
-
-def better_pdataframe_from_data(var=None, obs=None, selectvar=None, valuelabel=False, missingval=np.NaN):
-    pystata.config.check_initialized()
-
-    return better_dataframe_from_stata(None, var, obs, selectvar, valuelabel, missingval)
-
-def better_pdataframe_from_frame(stfr, var=None, obs=None, selectvar=None, valuelabel=False, missingval=np.NaN):
-    pystata.config.check_initialized()
-
-    return better_dataframe_from_stata(stfr, var, obs, selectvar, valuelabel, missingval)
-
-def better_dataframe_from_stata(stfr, var, obs, selectvar, valuelabel, missingval):
-    hdl = sfi.Data if stfr is None else sfi.Frame.connect(stfr)
-    
-    if hdl.getObsTotal() <= 0:
-        return None
-
-    # TODO: decide whether to use int, long, or float based on number of obs to be indexed
-    pystata.stata.run("""tempvar indexvar
-                         generate long `indexvar' = _n""", quietly=True)
-    idx_var = sfi.Macro.getLocal('indexvar')
-    
-    data = hdl.getAsDict(var, obs, selectvar, valuelabel, missingval)
-
-    # TODO: splice idx_var and var to this can be done in one call
-    idx = hdl.getAsDict(idx_var, obs, selectvar, valuelabel, missingval).pop(idx_var)
-
-    return pd.DataFrame(data=data, index=idx).convert_dtypes()
-
 
 class StataMagics():
     html_base = "https://www.stata.com"

--- a/pystata-kernel/utils.py
+++ b/pystata-kernel/utils.py
@@ -67,3 +67,5 @@ def mac_find_path():
         return ''
     else:
         return str(path)
+
+


### PR DESCRIPTION
This is a syntax-compatible reimplementation of `pystata.pandas2stata.dataframe_from_stata` and its wrapper functions `pystata.stata.pdataframe_from_data` and `pystata.stata.pdataframe_from_frame`.

It adds two features over the pystata version:

1. When invoked, it generates a `tempvar` containing `_n` and supplies this to `pd.DataFrame()` as the `index` parameter—so the row indexes of the generated DataFrame will match the observation numbers in Stata, even if the returned rows are discontinuous.
2. It calls `pd.DataFrame.convert_dtypes()` before returning, to cast the dataframe columns to types supporting `pd.NA`.

It also uses `pd.NA` as the default missing value, rather than Stata's `_DefaultMissing` class. (This is a bit wacky in implementation: it tells Stata to use `np.NaN` as the default missing, but `pd.DataFrame.convert_dtypes()` will convert `np.NaN` to `pd.NA` as part of casting the columns to nullable dtypes. This does mean there's no way to explicitly use `np.NaN` for missing.)

The `*%browse` magic is changed accordingly, to call these functions rather than pystata's.

Ways in which this could be improved:
- Find out what happens if we generate a tempvar and the dataset already contains the maximum number of variables (probably only a realistic problem with Stata/BE)
- Generate the index tempvar as `int`, `long`, `float` or `double` based on the smallest variable type that can hold the number of observations that need to be indexed (at the moment it's always `long`)
- Refactor the call to `sfi.Data.getAsDict` to get the data and indices as one call rather than two

This is my first time writing non-trivial python, so apologies if I've done things in non-idiomatic ways…