### PR TITLE
Add "(pystata-kernel)" to kernel display_name

### DIFF
--- a/pystata-kernel/install.py
+++ b/pystata-kernel/install.py
@@ -14,7 +14,7 @@ from textwrap import dedent
 
 kernel_json = {
     "argv": [sys.executable, "-m", "pystata-kernel", "-f", "{connection_file}"],
-    "display_name": "Stata",
+    "display_name": "Stata (pystata-kernel)",
     "language": "stata",
 }
 


### PR DESCRIPTION
...to help distinguish from pre-existing installations of stata-kernel.