### PR TITLE
Fixes to noecho parsing

### DIFF
--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -127,7 +127,7 @@ def clean_code(code, noisily=False):
                            and not (cs == 'program di'
                                     or cs == 'program dir'
                                     or cs.startswith('program drop ')
-                                    _startswith_stata_abbrev(cs, 'program list', 'program l'))
+                                    _startswith_stata_abbrev(cs, 'program list', 'program l')))
         return (_starts_program
                 or (cs in ['mata', 'mata:'])
                 or (cs in ['python', 'python:']))

--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -165,10 +165,6 @@ def clean_code(code, noisily=False):
                     or cs.startswith('while')
                     or in_program):
                 c = 'noisily ' + c
-            elif (cs.startswith('forv')
-                  or cs.startswith('foreach')
-                  or cs.startswith('while')):
-                c = 'quietly ' + c
             co.append(c)
 
             # Are we ending a program definition?

--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -134,16 +134,16 @@ def clean_code(code, noisily=False):
             if  'program define' in cs:
                 in_program = True
 
-            if not (cs.startswith('quietly') 
-                    or cs.startswith('noisily') 
+            if not (cs.startswith('qui') 
+                    or cs.startswith('noisily')
                     or cs.startswith('}')
                     or cs.startswith('end')
-                    or cs.startswith('forvalues')
+                    or cs.startswith('forv')
                     or cs.startswith('foreach')
                     or cs.startswith('while')
                     or in_program):
                 c = 'noisily ' + c
-            elif (cs.startswith('forvalues')
+            elif (cs.startswith('forv')
                   or cs.startswith('foreach')
                   or cs.startswith('while')):
                 c = 'quietly ' + c

--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -127,7 +127,7 @@ def clean_code(code, noisily=False):
                            and not (cs == 'program di'
                                     or cs == 'program dir'
                                     or cs.startswith('program drop ')
-                                    _startswith_stata_abbrev(cs, 'program list', 'program l')))
+                                    or _startswith_stata_abbrev(cs, 'program list', 'program l')))
         return (_starts_program
                 or (cs in ['mata', 'mata:'])
                 or (cs in ['python', 'python:']))

--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -122,8 +122,7 @@ def clean_code(code, noisily=False):
     # Replace multiple whitespace with one
     code = multi_regex.sub(' ',code)
 
-    # Add 'noisely' to each newline
-    # Add 'noisely' to each newline
+    # Add 'noisily' to each newline
     if noisily:
         cl = code.splitlines()
         co = []
@@ -143,6 +142,10 @@ def clean_code(code, noisily=False):
                     or cs.startswith('while')
                     or in_program):
                 c = 'noisily ' + c
+            elif (cs.startswith('forvalues')
+                  or cs.startswith('foreach')
+                  or cs.startswith('while')):
+                c = 'quietly ' + c
             co.append(c)
 
             # Are we ending a program definition?

--- a/pystata-kernel/helpers.py
+++ b/pystata-kernel/helpers.py
@@ -137,6 +137,7 @@ def clean_code(code, noisily=False):
             if not (cs.startswith('quietly') 
                     or cs.startswith('noisily') 
                     or cs.startswith('}')
+                    or cs.startswith('end')
                     or cs.startswith('forvalues')
                     or cs.startswith('foreach')
                     or cs.startswith('while')


### PR DESCRIPTION
Related to #16 

Known issues remaining:
`quietly` and `capture` blocks should not prepend `noisily` to commands within the block

(I'm starting to think basing the noecho code on `program` blocks (#15) would have been easier than the `quietly`-`noisily` approach, after all.)